### PR TITLE
Update spacewalk-remove-old-packages.py

### DIFF
--- a/spacewalk-remove-old-packages/spacewalk-remove-old-packages.py
+++ b/spacewalk-remove-old-packages/spacewalk-remove-old-packages.py
@@ -39,7 +39,7 @@
 #                         Config file for servers, users, passwords
 #   -c CHANNEL, --channel=CHANNEL
 #                         Channel Label: ie."myown-rhel-6-x86_64"
-#   -w, --without_channels
+#   -w, --without-channels
 #                         Delete packages without channel. Overwrites the
 #                         channel option
 #   -n, --dryrun          No Change is actually made, only print what would be


### PR DESCRIPTION
has in Readme, the script should say "--without-channels" instead of "--without_channels"
