### PR TITLE
Update spacewalk-orgclone-channel.py

### DIFF
--- a/spacewalk-orgchannel-clone/spacewalk-orgclone-channel.py
+++ b/spacewalk-orgchannel-clone/spacewalk-orgclone-channel.py
@@ -76,6 +76,8 @@ def parse_args():
 # Create the new channel and copy the details
 def create_dst_channel(spacewalk, spacekey, options):
     channel_details=spacewalk.channel.software.getDetails(spacekey, options.src_channel)
+    if 'checksum_label' not in channel_details:
+      channel_details['checksum_label'] = 'sha1'
     ret=spacewalk.channel.software.create(spacekey, \
         options.dst_channel, \
         "%s %s" % (options.channel_name_prefix, channel_details['name']), \


### PR DESCRIPTION
['checksum_label'] Could be set to 'none' which means the key/val pair isn't set, which causes the script to fail. This change ensures checksum occurs on the new channel
