### PR TITLE
Update spacewalk-orgclone-channel.py

### DIFF
--- a/spacewalk-orgchannel-clone/spacewalk-orgclone-channel.py
+++ b/spacewalk-orgchannel-clone/spacewalk-orgclone-channel.py
@@ -78,6 +78,10 @@ def create_dst_channel(spacewalk, spacekey, options):
     channel_details=spacewalk.channel.software.getDetails(spacekey, options.src_channel)
     if 'checksum_label' not in channel_details:
       channel_details['checksum_label'] = 'sha1'
+    if channel_details['arch_name'] == 'IA-32':
+      channel_details['arch_name'] = 'ia32'
+    elif channel_details['arch_name'] == 'IA-64':
+      channel_details['arch_name'] = 'ia64'
     ret=spacewalk.channel.software.create(spacekey, \
         options.dst_channel, \
         "%s %s" % (options.channel_name_prefix, channel_details['name']), \


### PR DESCRIPTION
AI-\* is missing - when defining architecture
