### PR TITLE
Truncate `to_delete_ids`

### DIFF
--- a/spacewalk-remove-old-packages/spacewalk-remove-old-packages.py
+++ b/spacewalk-remove-old-packages/spacewalk-remove-old-packages.py
@@ -146,8 +146,12 @@ def main():
         print "Getting all packages which match %s" % options.lucene
         to_delete = spacewalk.packages.search.advanced(spacekey, options.lucene)
 
-    if options.max and len(to_delete) > options.max:
-        to_delete = to_delete[:options.max]
+    if options.max:
+        if len(to_delete) > options.max:
+            to_delete = to_delete[:options.max]
+        if len(to_delete_ids) > options.max:
+            to_delete_ids = to_delete_ids[:options.max]
+
 
     print "Packages to remove: %s" % len(to_delete)
 


### PR DESCRIPTION
My previous patch seemed correct because the "Delete package" messages counted correctly. Unfortunately, I neglected to truncate `to_delete_ids`, so all the packages would have still been deleted from channel. I've added the `len` of `to_delete_ids` to the output for confirmation.
