### PR TITLE
Add regex to match ^hostname on top of system.search

### DIFF
--- a/spacewalk-generate-reinstall-key/spacewalk-generate-reinstall-key.py
+++ b/spacewalk-generate-reinstall-key/spacewalk-generate-reinstall-key.py
@@ -87,8 +87,14 @@ def main():
     spacewalk = xmlrpclib.Server("https://%s/rpc/api" % spw_server, verbose=0)
     spacekey = spacewalk.auth.login(spw_user,spw_pass)
 
-    
-    foundsystems = spacewalk.system.search.hostname(spacekey, options.servername)
+    # Spacewalk Search is equivalent to *servername*
+    systems = spacewalk.system.search.hostname(spacekey, options.servername)
+
+    # Search only for those servers where the name is matching ^servername
+    foundsystems = []
+    for system in systems:
+      if re.match("^(" + options.servername + ").*", system["name"]):
+        foundsystems.append(system)
 
     if len(foundsystems) == 0:
         debug("No systems found.")


### PR DESCRIPTION
The spacewalk api call system.search, is equivalent to *servername*, which causes problems, if there are for example two servers, named:

servername and dbservername

To fix this, the results from system.search are again checked against the Regex ^servername, which drops the dbservername from the above result.

Duplicates are still preserved (as it was before).